### PR TITLE
Allow mal-id recognition in Specials's subfolders

### DIFF
--- a/Jellyfin.Plugin.MyAnimeList/Providers/MyAnimeList/Helpers/MalIdResolver.cs
+++ b/Jellyfin.Plugin.MyAnimeList/Providers/MyAnimeList/Helpers/MalIdResolver.cs
@@ -1,4 +1,6 @@
+using System;
 using MediaBrowser.Controller.Providers;
+using System.IO;
 using System.Text.RegularExpressions;
 
 namespace Jellyfin.Plugin.MyAnimeList.Providers.MyAnimeList.Helpers
@@ -38,6 +40,35 @@ namespace Jellyfin.Plugin.MyAnimeList.Providers.MyAnimeList.Helpers
             }
 
             return null;
+        }
+
+        // Gets a MAL ID from a folder's name directly inside a "Specials" (or Season 00) folder.
+        public static long? TryGetSpecialFolderMalId(ItemLookupInfo info)
+        {
+            if (info is not EpisodeInfo episode || episode.IndexNumber is null || episode.ParentIndexNumber != 0)
+                return null;
+
+            if (string.IsNullOrWhiteSpace(info.Path))
+                return null;
+
+            var specialFolder = Path.GetDirectoryName(info.Path);
+            if (string.IsNullOrWhiteSpace(specialFolder))
+                return null;
+
+            var specialFolderName = Path.GetFileName(specialFolder);
+            if (string.IsNullOrWhiteSpace(specialFolderName))
+                return null;
+
+            var containerFolder = Path.GetDirectoryName(specialFolder);
+            if (string.IsNullOrWhiteSpace(containerFolder))
+                return null;
+
+            var containerName = Path.GetFileName(containerFolder);
+            if (!string.Equals(containerName, "Specials", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(containerName, "Season 00", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            return ExtractMalIdFromSearchName(specialFolderName);
         }
 
         private static readonly Regex MalIdRegex = new Regex(@"\[mal-(\d+)\]", RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/Jellyfin.Plugin.MyAnimeList/Providers/MyAnimeList/MetaData Providers/EpisodeProvider.cs
+++ b/Jellyfin.Plugin.MyAnimeList/Providers/MyAnimeList/MetaData Providers/EpisodeProvider.cs
@@ -55,7 +55,59 @@ namespace Jellyfin.Plugin.MyAnimeList.Providers.MyAnimeList.MetaData
             AnimeObject anime = null;
             int seasonnumber = info.ParentIndexNumber ?? 1;
 
-            if (Config.UseExternalIDs && info.ProviderIds.TryGetValue("Tvdb", out var tvdbid) && seasonnumber == 0)
+            // If a special lives in a subfolder directly under Specials/Season 00,
+            // allow the folder's [mal-ID] to identify the MAL anime/entry directly.
+            var specialFolderMalId = MalIdResolver.TryGetSpecialFolderMalId(info);
+            if (specialFolderMalId.HasValue)
+            {
+                if (enableDebug)
+                    _log.LogInformation(
+                        "Found MAL ID {MalId} in special folder for {Path}",
+                        specialFolderMalId.Value,
+                        info.Path);
+
+                var specialAnime = await JikanAPI
+                    .GetAnimeFullAsync(specialFolderMalId.Value, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (specialAnime?.MalId is not null)
+                {
+                    anime = new AnimeObject
+                    {
+                        Anime = specialAnime
+                    };
+
+                    // For single episode entry, use the MAL entry itself.
+                    // For multi-episode entries, use the Jellyfin episode number to
+                    // request the corresponding MAL episode.
+                    if (specialAnime.Episodes.GetValueOrDefault() == 1)
+                    {
+                        episodeData = anime.toEpisodeData();
+                    }
+                    else
+                    {
+                        episodeData = await JikanAPI
+                            .GetAnimeEpisodeAsync(
+                                specialAnime.MalId.Value,
+                                info.IndexNumber.Value,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+
+                    if (episodeData?.Url is null)
+                    {
+                        _log.LogInformation(
+                            "Episode data null for MAL ID {MalId}, episode {EpisodeNumber}",
+                            specialAnime.MalId.Value,
+                            info.IndexNumber.Value);
+                    }
+                }
+            }
+
+            if (episodeData is null &&
+                Config.UseExternalIDs &&
+                info.ProviderIds.TryGetValue("Tvdb", out var tvdbid) &&
+                seasonnumber == 0)
             {
                 if (enableDebug) _log.LogInformation("Found TVDB ID {TvdbId}", tvdbid);
 


### PR DESCRIPTION
### Add MAL ID support for special subfolders
_Related to #14_ 

Currently, it's hard to consistently identify specials using only the episode's name or number.
There's often incorrect metadata (especially on Anime with multiple specials..)

This change allows a MAL ID to be specified in the name of a special subfolder:
```text
MyAnime/
└── Specials/
    ├── Special A [mal-12345]/
    │   └── Special A - S00E01.mkv
    └── Special B [mal-67890]/
        └── Special B - S00E01.mkv
        └── Special B - S00E02.mkv
```
The `[mal-ID]` in the special's subfolder is used to identify the corresponding MAL entry and retrieve its metadata.

### Behavior
* This change only impacts subfolders where the "[mal-ID]" is present
* The subfolders doesn't impact Jellyfin's "Specials" UI display
* Each special subfolder can have its own MAL ID
* Episodes within each subfolder can start at "S00E01", independently of episodes in other subfolders

### Testing
I only tested with Jellyfin 10.11.11
I don't know if it'll handle all cases, but i had 100% metadata accuracy in my library